### PR TITLE
Pass --atomic to isort

### DIFF
--- a/python-isort.el
+++ b/python-isort.el
@@ -44,7 +44,7 @@
   :type 'string
   :group 'python-isort)
 
-(defcustom python-isort-arguments '("--stdout" "-")
+(defcustom python-isort-arguments '("--stdout" "--atomic" "-")
   "Arguments to `python-isort-command'."
   :type '(repeat string)
   :group 'python-isort)


### PR DESCRIPTION
The --atomic flag ‘ensures the output doesn't save if
the resulting file contains syntax errors’ (from docs).